### PR TITLE
Verbosity in report generation

### DIFF
--- a/route_policy_cmp/src/bgp.rs
+++ b/route_policy_cmp/src/bgp.rs
@@ -3,3 +3,6 @@ pub mod filter;
 pub mod map;
 pub mod peering;
 pub mod report;
+pub mod verbosity;
+
+pub use {cmp::Compare, verbosity::Verbosity};

--- a/route_policy_cmp/src/bgp/cmp.rs
+++ b/route_policy_cmp/src/bgp/cmp.rs
@@ -16,17 +16,10 @@ use super::{
     map::{parse_table_dump, AsPathEntry},
     peering::CheckPeering,
     report::*,
+    verbosity::Verbosity,
 };
 
 pub const RECURSION_LIMIT: isize = 0x100;
-
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum Verbosity {
-    ErrOnly,
-    Brief,
-    ShowSkips,
-    Detailed,
-}
 
 pub struct Compare<'a> {
     pub dump: &'a Dump,

--- a/route_policy_cmp/src/bgp/filter.rs
+++ b/route_policy_cmp/src/bgp/filter.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::{
     cmp::Compare,
-    report::{ReportItem::*, *},
+    report::*,
     verbosity::{Verbosity, VerbosityReport},
 };
 
@@ -207,9 +207,10 @@ impl<'a> CheckFilter<'a> {
         }
         match self.check(filter, depth) {
             Some((_errors, true)) => None,
-            Some((mut skips, false)) => {
-                skips.push(Skip(SkipReason::SkippedNotFilterResult));
-                Some((skips, false))
+            Some(report @ (_, false)) => {
+                let mut aggregator: AnyReportAggregator = report.into();
+                aggregator.join(self.no_match_any_report(|| MatchProblem::NotFilterMatch)?);
+                aggregator.to_any()
             }
             None => self.no_match_any_report(|| MatchProblem::NotFilterMatch),
         }

--- a/route_policy_cmp/src/bgp/filter.rs
+++ b/route_policy_cmp/src/bgp/filter.rs
@@ -9,12 +9,13 @@ use crate::{
 };
 
 use super::{
-    cmp::Compare,
+    cmp::{Compare, Verbosity},
     report::{ReportItem::*, *},
 };
 
 pub struct CheckFilter<'a> {
     pub compare: &'a Compare<'a>,
+    pub verbosity: Verbosity,
 }
 
 impl<'a> CheckFilter<'a> {

--- a/route_policy_cmp/src/bgp/filter.rs
+++ b/route_policy_cmp/src/bgp/filter.rs
@@ -40,10 +40,43 @@ impl<'a> CheckFilter<'a> {
         }
     }
 
+    fn skip_any_report<F>(&self, reason: F) -> AnyReport
+    where
+        F: Fn() -> SkipReason,
+    {
+        if self.verbosity >= Verbosity::ShowSkips {
+            skip_any_report(reason())
+        } else {
+            empty_skip_any_report()
+        }
+    }
+
+    fn no_match_any_report<F>(&self, reason: F) -> AnyReport
+    where
+        F: Fn() -> MatchProblem,
+    {
+        if self.verbosity >= Verbosity::Detailed {
+            no_match_any_report(reason())
+        } else {
+            failed_any_report()
+        }
+    }
+
+    fn bad_rpsl_any_report<F>(&self, reason: F) -> AnyReport
+    where
+        F: Fn() -> RpslError,
+    {
+        if self.verbosity >= Verbosity::Detailed {
+            bad_rpsl_any_report(reason())
+        } else {
+            failed_any_report()
+        }
+    }
+
     fn filter_set(&self, name: &str, depth: isize) -> AnyReport {
         let filter_set = match self.compare.dump.filter_sets.get(name) {
             Some(f) => f,
-            None => return skip_any_report(SkipReason::FilterSetUnrecorded(name.into())),
+            None => return self.skip_any_report(|| SkipReason::FilterSetUnrecorded(name.into())),
         };
         let mut aggregator = AnyReportAggregator::new();
         for filter in &filter_set.filters {
@@ -56,7 +89,7 @@ impl<'a> CheckFilter<'a> {
         // TODO: Only report when `num` is on AS path.
         let routes = match self.compare.dump.as_routes.get(&num) {
             Some(r) => r,
-            None => return skip_any_report(SkipReason::AsRoutesUnrecorded(num)),
+            None => return self.skip_any_report(|| SkipReason::AsRoutesUnrecorded(num)),
         };
         let ranges: Vec<_> = routes
             .iter()
@@ -67,7 +100,7 @@ impl<'a> CheckFilter<'a> {
             .collect();
         let (reports, all_fail) = self.filter_prefixes(&ranges)?;
         if all_fail {
-            no_match_any_report(MatchProblem::FilterAsNum(num, range_operator))
+            self.no_match_any_report(|| MatchProblem::FilterAsNum(num, range_operator))
         } else {
             Some((reports, all_fail))
         }
@@ -77,10 +110,14 @@ impl<'a> CheckFilter<'a> {
     where
         I: IntoIterator<Item = &'a AddrPfxRange>,
     {
-        prefixes
+        if prefixes
             .into_iter()
             .all(|prefix| !prefix.contains(&self.compare.prefix))
-            .then(|| no_match_any_report(MatchProblem::FilterPrefixes).unwrap())
+        {
+            self.no_match_any_report(|| MatchProblem::FilterPrefixes)
+        } else {
+            None
+        }
     }
 
     fn filter_route_set(&self, name: &str, op: &RangeOperator, depth: isize) -> AnyReport {
@@ -89,14 +126,14 @@ impl<'a> CheckFilter<'a> {
         }
         let route_set = match self.compare.dump.route_sets.get(name) {
             Some(r) => r,
-            None => return skip_any_report(SkipReason::RouteSetUnrecorded(name.into())),
+            None => return self.skip_any_report(|| SkipReason::RouteSetUnrecorded(name.into())),
         };
         let mut aggregator = AnyReportAggregator::new();
         for member in &route_set.members {
             aggregator.join(self.filter_route_set_member(member, op, depth - 1)?);
         }
         if aggregator.all_fail {
-            no_match_any_report(MatchProblem::FilterRouteSet(name.into()))
+            self.no_match_any_report(|| MatchProblem::FilterRouteSet(name.into()))
         } else {
             aggregator.to_any()
         }
@@ -136,14 +173,14 @@ impl<'a> CheckFilter<'a> {
         }
         let as_set = match self.compare.dump.as_sets.get(name) {
             Some(r) => r,
-            None => return skip_any_report(SkipReason::AsSetUnrecorded(name.into())),
+            None => return self.skip_any_report(|| SkipReason::AsSetUnrecorded(name.into())),
         };
         let mut aggregator = AnyReportAggregator::new();
         for as_name in &as_set.members {
             aggregator.join(self.filter_as_name(as_name, op, depth - 1, visited)?);
         }
         if aggregator.all_fail {
-            no_match_any_report(MatchProblem::FilterAsSet(name.into(), *op))
+            self.no_match_any_report(|| MatchProblem::FilterAsSet(name.into(), *op))
         } else {
             aggregator.to_any()
         }
@@ -151,7 +188,7 @@ impl<'a> CheckFilter<'a> {
 
     fn filter_as_regex(&self, expr: &str) -> AnyReport {
         // TODO: Implement.
-        skip_any_report(SkipReason::AsRegexUnimplemented(expr.into()))
+        self.skip_any_report(|| SkipReason::AsRegexUnimplemented(expr.into()))
     }
 
     fn filter_as_name<'v>(
@@ -171,7 +208,9 @@ impl<'a> CheckFilter<'a> {
         match as_name {
             AsName::Num(num) => self.filter_as_num(*num, op),
             AsName::Set(name) => self.filter_as_set(name, op, depth - 1, visited),
-            AsName::Invalid(reason) => bad_rpsl_any_report(RpslError::InvalidAsName(reason.into())),
+            AsName::Invalid(reason) => {
+                self.bad_rpsl_any_report(|| RpslError::InvalidAsName(reason.into()))
+            }
         }
     }
 
@@ -204,16 +243,16 @@ impl<'a> CheckFilter<'a> {
                 skips.push(Skip(SkipReason::SkippedNotFilterResult));
                 Some((skips, false))
             }
-            None => no_match_any_report(MatchProblem::NotFilterMatch),
+            None => self.no_match_any_report(|| MatchProblem::NotFilterMatch),
         }
     }
 
     fn filter_community(&self, community: &Call) -> AnyReport {
         // TODO: Implement.
-        skip_any_report(SkipReason::CommunityCheckUnimplemented(community.clone()))
+        self.skip_any_report(|| SkipReason::CommunityCheckUnimplemented(community.clone()))
     }
 
     fn invalid_filter(&self, reason: &str) -> AnyReport {
-        bad_rpsl_any_report(RpslError::InvalidFilter(reason.into()))
+        self.bad_rpsl_any_report(|| RpslError::InvalidFilter(reason.into()))
     }
 }

--- a/route_policy_cmp/src/bgp/filter.rs
+++ b/route_policy_cmp/src/bgp/filter.rs
@@ -9,8 +9,9 @@ use crate::{
 };
 
 use super::{
-    cmp::{Compare, Verbosity},
+    cmp::Compare,
     report::{ReportItem::*, *},
+    verbosity::{Verbosity, VerbosityReport},
 };
 
 pub struct CheckFilter<'a> {
@@ -37,39 +38,6 @@ impl<'a> CheckFilter<'a> {
             Group(filter) => self.check(filter, depth),
             Community(community) => self.filter_community(community),
             Invalid(reason) => self.invalid_filter(reason),
-        }
-    }
-
-    fn skip_any_report<F>(&self, reason: F) -> AnyReport
-    where
-        F: Fn() -> SkipReason,
-    {
-        if self.verbosity >= Verbosity::ShowSkips {
-            skip_any_report(reason())
-        } else {
-            empty_skip_any_report()
-        }
-    }
-
-    fn no_match_any_report<F>(&self, reason: F) -> AnyReport
-    where
-        F: Fn() -> MatchProblem,
-    {
-        if self.verbosity >= Verbosity::Detailed {
-            no_match_any_report(reason())
-        } else {
-            failed_any_report()
-        }
-    }
-
-    fn bad_rpsl_any_report<F>(&self, reason: F) -> AnyReport
-    where
-        F: Fn() -> RpslError,
-    {
-        if self.verbosity >= Verbosity::Detailed {
-            bad_rpsl_any_report(reason())
-        } else {
-            failed_any_report()
         }
     }
 
@@ -254,5 +222,11 @@ impl<'a> CheckFilter<'a> {
 
     fn invalid_filter(&self, reason: &str) -> AnyReport {
         self.bad_rpsl_any_report(|| RpslError::InvalidFilter(reason.into()))
+    }
+}
+
+impl<'a> VerbosityReport for CheckFilter<'a> {
+    fn verbosity(&self) -> Verbosity {
+        self.verbosity
     }
 }

--- a/route_policy_cmp/src/bgp/filter.rs
+++ b/route_policy_cmp/src/bgp/filter.rs
@@ -227,7 +227,7 @@ impl<'a> CheckFilter<'a> {
 }
 
 impl<'a> VerbosityReport for CheckFilter<'a> {
-    fn verbosity(&self) -> Verbosity {
+    fn get_verbosity(&self) -> Verbosity {
         self.verbosity
     }
 }

--- a/route_policy_cmp/src/bgp/peering.rs
+++ b/route_policy_cmp/src/bgp/peering.rs
@@ -5,8 +5,9 @@ use crate::parse::{
 };
 
 use super::{
-    cmp::{Compare, Verbosity},
+    cmp::Compare,
     report::{ReportItem::*, *},
+    verbosity::{Verbosity, VerbosityReport},
 };
 
 pub struct CheckPeering<'a> {
@@ -65,7 +66,9 @@ impl<'a> CheckPeering<'a> {
         match as_name {
             AsName::Num(num) => self.check_remote_as_num(*num),
             AsName::Set(name) => self.check_remote_as_set(name, depth),
-            AsName::Invalid(reason) => bad_rpsl_any_report(RpslError::InvalidAsName(reason.into())),
+            AsName::Invalid(reason) => {
+                self.bad_rpsl_any_report(|| RpslError::InvalidAsName(reason.into()))
+            }
         }
     }
 
@@ -73,7 +76,7 @@ impl<'a> CheckPeering<'a> {
         if self.accept_num == num {
             None
         } else {
-            no_match_any_report(MatchProblem::RemoteAsNum(num))
+            self.no_match_any_report(|| MatchProblem::RemoteAsNum(num))
         }
     }
 
@@ -83,14 +86,14 @@ impl<'a> CheckPeering<'a> {
         }
         let as_set = match self.compare.dump.as_sets.get(name) {
             Some(r) => r,
-            None => return skip_any_report(SkipReason::AsSetUnrecorded(name.into())),
+            None => return self.skip_any_report(|| SkipReason::AsSetUnrecorded(name.into())),
         };
         let mut aggregator = AnyReportAggregator::new();
         for as_name in &as_set.members {
             aggregator.join(self.check_remote_as_name(as_name, depth - 1)?);
         }
         if aggregator.all_fail {
-            no_match_any_report(MatchProblem::RemoteAsSet(name.into()))
+            self.no_match_any_report(|| MatchProblem::RemoteAsSet(name.into()))
         } else {
             aggregator.to_any()
         }
@@ -102,7 +105,7 @@ impl<'a> CheckPeering<'a> {
         }
         let peering_set = match self.compare.dump.peering_sets.get(name) {
             Some(r) => r,
-            None => return skip_any_report(SkipReason::PeeringSetUnrecorded(name.into())),
+            None => return self.skip_any_report(|| SkipReason::PeeringSetUnrecorded(name.into())),
         };
         let mut aggregator = AnyReportAggregator::new();
         for peering in &peering_set.peerings {
@@ -141,8 +144,14 @@ impl<'a> CheckPeering<'a> {
                 skips.push(Skip(SkipReason::SkippedExceptPeeringResult));
                 Ok(Some(skips))
             }
-            None => no_match_all_report(MatchProblem::ExceptFilterRightMatch),
+            None => self.no_match_all_report(|| MatchProblem::ExceptFilterRightMatch),
         };
         left_report.join(right_report?).to_all()
+    }
+}
+
+impl<'a> VerbosityReport for CheckPeering<'a> {
+    fn verbosity(&self) -> Verbosity {
+        self.verbosity
     }
 }

--- a/route_policy_cmp/src/bgp/peering.rs
+++ b/route_policy_cmp/src/bgp/peering.rs
@@ -5,13 +5,14 @@ use crate::parse::{
 };
 
 use super::{
-    cmp::Compare,
+    cmp::{Compare, Verbosity},
     report::{ReportItem::*, *},
 };
 
 pub struct CheckPeering<'a> {
     pub compare: &'a Compare<'a>,
     pub accept_num: usize,
+    pub verbosity: Verbosity,
 }
 
 impl<'a> CheckPeering<'a> {

--- a/route_policy_cmp/src/bgp/peering.rs
+++ b/route_policy_cmp/src/bgp/peering.rs
@@ -151,7 +151,7 @@ impl<'a> CheckPeering<'a> {
 }
 
 impl<'a> VerbosityReport for CheckPeering<'a> {
-    fn verbosity(&self) -> Verbosity {
+    fn get_verbosity(&self) -> Verbosity {
         self.verbosity
     }
 }

--- a/route_policy_cmp/src/bgp/report.rs
+++ b/route_policy_cmp/src/bgp/report.rs
@@ -122,6 +122,10 @@ pub fn skip_all_report(reason: SkipReason) -> AllReport {
     Ok(Some(skips))
 }
 
+pub const fn empty_skip_all_report() -> AllReport {
+    Ok(Some(vec![]))
+}
+
 pub fn no_match_all_report(reason: MatchProblem) -> AllReport {
     let errors = vec![NoMatch(reason)];
     Err(errors)
@@ -130,6 +134,10 @@ pub fn no_match_all_report(reason: MatchProblem) -> AllReport {
 pub fn recursion_all_report(reason: RecurSrc) -> AllReport {
     let errors = vec![Recursion(reason)];
     Err(errors)
+}
+
+pub const fn failed_match_all_report() -> AllReport {
+    Err(vec![])
 }
 
 /// Useful if any of the reports succeeding is enough.
@@ -141,6 +149,10 @@ pub type AnyReport = Option<(ReportItems, bool)>;
 pub fn skip_any_report(reason: SkipReason) -> AnyReport {
     let skips = vec![Skip(reason)];
     Some((skips, false))
+}
+
+pub const fn empty_skip_any_report() -> AnyReport {
+    Some((vec![], false))
 }
 
 pub fn no_match_any_report(reason: MatchProblem) -> AnyReport {
@@ -158,7 +170,8 @@ pub fn recursion_any_report(reason: RecurSrc) -> AnyReport {
     Some((errors, true))
 }
 
-pub fn failed_any_report() -> AnyReport {
+/// Empty failed `AnyReport`.
+pub const fn failed_any_report() -> AnyReport {
     Some((vec![], true))
 }
 

--- a/route_policy_cmp/src/bgp/report.rs
+++ b/route_policy_cmp/src/bgp/report.rs
@@ -12,11 +12,16 @@ use super::map::AsPathEntry;
 /// Use this in an `Option`, and use `None` to indicate "good."
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum Report {
+    Good(Vec<ReportItem>),
     Neutral(Vec<ReportItem>),
     Bad(Vec<ReportItem>),
 }
 
 impl Report {
+    pub fn success(reason: SuccessType) -> Self {
+        Good(vec![Success(reason)])
+    }
+
     pub fn skip(reason: SkipReason) -> Self {
         Neutral(vec![Skip(reason)])
     }
@@ -24,10 +29,18 @@ impl Report {
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ReportItem {
+    Success(SuccessType),
     Skip(SkipReason),
     NoMatch(MatchProblem),
     BadRpsl(RpslError),
     Recursion(RecurSrc),
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum SuccessType {
+    Export(usize, usize),
+    ExportSingle(usize),
+    Import(usize, usize),
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]

--- a/route_policy_cmp/src/bgp/report.rs
+++ b/route_policy_cmp/src/bgp/report.rs
@@ -131,12 +131,17 @@ pub fn no_match_all_report(reason: MatchProblem) -> AllReport {
     Err(errors)
 }
 
+pub fn bad_rpsl_all_report(reason: RpslError) -> AllReport {
+    let errors = vec![BadRpsl(reason)];
+    Err(errors)
+}
+
 pub fn recursion_all_report(reason: RecurSrc) -> AllReport {
     let errors = vec![Recursion(reason)];
     Err(errors)
 }
 
-pub const fn failed_match_all_report() -> AllReport {
+pub const fn failed_all_report() -> AllReport {
     Err(vec![])
 }
 

--- a/route_policy_cmp/src/bgp/verbosity.rs
+++ b/route_policy_cmp/src/bgp/verbosity.rs
@@ -1,0 +1,79 @@
+use super::report::*;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Verbosity {
+    ErrOnly,
+    Brief,
+    ShowSkips,
+    Detailed,
+}
+
+pub trait VerbosityReport {
+    fn verbosity(&self) -> Verbosity;
+
+    fn skip_any_report<F>(&self, reason: F) -> AnyReport
+    where
+        F: Fn() -> SkipReason,
+    {
+        if self.verbosity() >= Verbosity::ShowSkips {
+            skip_any_report(reason())
+        } else {
+            empty_skip_any_report()
+        }
+    }
+
+    fn no_match_any_report<F>(&self, reason: F) -> AnyReport
+    where
+        F: Fn() -> MatchProblem,
+    {
+        if self.verbosity() >= Verbosity::Detailed {
+            no_match_any_report(reason())
+        } else {
+            failed_any_report()
+        }
+    }
+
+    fn bad_rpsl_any_report<F>(&self, reason: F) -> AnyReport
+    where
+        F: Fn() -> RpslError,
+    {
+        if self.verbosity() >= Verbosity::Detailed {
+            bad_rpsl_any_report(reason())
+        } else {
+            failed_any_report()
+        }
+    }
+
+    fn skip_all_report<F>(&self, reason: F) -> AllReport
+    where
+        F: Fn() -> SkipReason,
+    {
+        if self.verbosity() >= Verbosity::ShowSkips {
+            skip_all_report(reason())
+        } else {
+            empty_skip_all_report()
+        }
+    }
+
+    fn no_match_all_report<F>(&self, reason: F) -> AllReport
+    where
+        F: Fn() -> MatchProblem,
+    {
+        if self.verbosity() >= Verbosity::Detailed {
+            no_match_all_report(reason())
+        } else {
+            failed_all_report()
+        }
+    }
+
+    fn bad_rpsl_all_report<F>(&self, reason: F) -> AllReport
+    where
+        F: Fn() -> RpslError,
+    {
+        if self.verbosity() >= Verbosity::Detailed {
+            bad_rpsl_all_report(reason())
+        } else {
+            failed_all_report()
+        }
+    }
+}

--- a/route_policy_cmp/src/bgp/verbosity.rs
+++ b/route_policy_cmp/src/bgp/verbosity.rs
@@ -9,13 +9,43 @@ pub enum Verbosity {
 }
 
 pub trait VerbosityReport {
-    fn verbosity(&self) -> Verbosity;
+    fn get_verbosity(&self) -> Verbosity;
+
+    fn success_report<F>(&self, reason: F) -> Option<Report>
+    where
+        F: Fn() -> SuccessType,
+    {
+        if self.get_verbosity() >= Verbosity::Brief {
+            Some(Report::success(reason()))
+        } else {
+            None
+        }
+    }
+
+    fn skips_report(&self, skips: Vec<ReportItem>) -> Option<Report> {
+        if self.get_verbosity() >= Verbosity::ShowSkips {
+            Some(Report::Neutral(skips))
+        } else {
+            None
+        }
+    }
+
+    fn skip_report<F>(&self, reason: F) -> Option<Report>
+    where
+        F: Fn() -> SkipReason,
+    {
+        if self.get_verbosity() >= Verbosity::ShowSkips {
+            Some(Report::skip(reason()))
+        } else {
+            None
+        }
+    }
 
     fn skip_any_report<F>(&self, reason: F) -> AnyReport
     where
         F: Fn() -> SkipReason,
     {
-        if self.verbosity() >= Verbosity::ShowSkips {
+        if self.get_verbosity() >= Verbosity::ShowSkips {
             skip_any_report(reason())
         } else {
             empty_skip_any_report()
@@ -26,7 +56,7 @@ pub trait VerbosityReport {
     where
         F: Fn() -> MatchProblem,
     {
-        if self.verbosity() >= Verbosity::Detailed {
+        if self.get_verbosity() >= Verbosity::Detailed {
             no_match_any_report(reason())
         } else {
             failed_any_report()
@@ -37,7 +67,7 @@ pub trait VerbosityReport {
     where
         F: Fn() -> RpslError,
     {
-        if self.verbosity() >= Verbosity::Detailed {
+        if self.get_verbosity() >= Verbosity::Detailed {
             bad_rpsl_any_report(reason())
         } else {
             failed_any_report()
@@ -48,7 +78,7 @@ pub trait VerbosityReport {
     where
         F: Fn() -> SkipReason,
     {
-        if self.verbosity() >= Verbosity::ShowSkips {
+        if self.get_verbosity() >= Verbosity::ShowSkips {
             skip_all_report(reason())
         } else {
             empty_skip_all_report()
@@ -59,7 +89,7 @@ pub trait VerbosityReport {
     where
         F: Fn() -> MatchProblem,
     {
-        if self.verbosity() >= Verbosity::Detailed {
+        if self.get_verbosity() >= Verbosity::Detailed {
             no_match_all_report(reason())
         } else {
             failed_all_report()
@@ -70,7 +100,7 @@ pub trait VerbosityReport {
     where
         F: Fn() -> RpslError,
     {
-        if self.verbosity() >= Verbosity::Detailed {
+        if self.get_verbosity() >= Verbosity::Detailed {
             bad_rpsl_all_report(reason())
         } else {
             failed_all_report()

--- a/route_policy_cmp/src/test/notebook.rs
+++ b/route_policy_cmp/src/test/notebook.rs
@@ -1,10 +1,7 @@
 use super::*;
 use crate as route_policy_cmp;
 
-use route_policy_cmp::{
-    bgp::cmp::{Compare, Verbosity},
-    parse::dump::Dump,
-};
+use route_policy_cmp::{bgp::*, parse::dump::Dump};
 use std::{
     fs::File,
     io::{prelude::*, BufReader},

--- a/route_policy_cmp/src/test/notebook.rs
+++ b/route_policy_cmp/src/test/notebook.rs
@@ -1,13 +1,17 @@
 use super::*;
 use crate as route_policy_cmp;
 
-use route_policy_cmp::{bgp::cmp::Compare, parse::dump::Dump};
+use route_policy_cmp::{
+    bgp::cmp::{Compare, Verbosity},
+    parse::dump::Dump,
+};
 use std::{
     fs::File,
     io::{prelude::*, BufReader},
 };
 
 #[allow(dead_code)]
+#[allow(clippy::no_effect)]
 #[allow(unused_must_use)]
 fn example() -> Result<()> {
     let parsed = Dump::pal_read("parsed")?;
@@ -19,6 +23,8 @@ fn example() -> Result<()> {
 
     // Remove `;` in notebook.
     Compare::with_line_dump(&bgp_file[2], &parsed)?.check();
+
+    Verbosity::Brief > Verbosity::ErrOnly;
 
     Ok(())
 }


### PR DESCRIPTION
- `bgp::cmp::Compare` now has `verbosity: Verbosity` field.
- Generate `Report::Good` for `verbosity >= Brief`.
- Only show skips for `verbosity >= ShowSkips`.
- Only show errors for each steps for `verbosity >= Detailed`.
